### PR TITLE
fixed minor typo

### DIFF
--- a/schemas/org.gnome.shell.extensions.kube_config.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kube_config.gschema.xml
@@ -3,7 +3,7 @@
 	<schema path="/org/gnome/shell/extensions/kube-config/" id="org.gnome.shell.extensions.kube-config">
 		<key type="b" name="show-current-context">
             <default>false</default>
-            <summary>Show current contest</summary>
+            <summary>Show current context</summary>
             <description></description>
         </key>
 	</schema>


### PR DESCRIPTION
Was looking to tweak this extension and spotted this typo.. I've been a happy user of it for almost 2 years now (thanks)

`contest` -> `context`

