### PR TITLE
update metadata to indicate gnome shell 40.1 compatability

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     "url": "https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig",
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [
-        "40.0"
+        "40.0",
+        "40.1"
     ]
 }


### PR DESCRIPTION
Tried it out on gnome-shell `40.1.0` (fedora 34) and it seems fine