### PR TITLE
Updates to support gnome 42

### DIFF
--- a/kubeIndicator.js
+++ b/kubeIndicator.js
@@ -13,14 +13,12 @@ const Me = ExtensionUtils.getCurrentExtension();
 const KubePopupMenuItem = Me.imports.kubePopupMenuItem;
 const Util = imports.misc.util;
 
-const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' },
+var KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' },
     class KubeIndicator extends PanelMenu.Button {
         _init() {
             super._init(null, "Kube");
             this._settings = ExtensionUtils.getSettings();
             this.kcPath = GLib.get_home_dir() + "/.kube/config";
-
-            this.setMenu(new PopupMenu.PopupMenu(this.actor, 0.25, St.Side.TOP));
 
             this._setView()
 
@@ -77,17 +75,17 @@ const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' },
         }
 
         _setView() {
-            this.actor.remove_all_children();
+            this.remove_all_children();
             if (this._settings.get_boolean('show-current-context') == false) {
                 let gicon = Gio.icon_new_for_string(Me.path + '/icons/logo.svg');
                 this.icon = new St.Icon({ gicon: gicon, style_class: 'system-status-icon' });
-                this.actor.add_actor(this.icon);
+                this.add_actor(this.icon);
             } else {
                 this.label = new St.Label({
                     text: _("kubectl"),
                     y_align: Clutter.ActorAlign.CENTER
                 });
-                this.actor.add_actor(this.label);
+                this.add_actor(this.label);
             }
             this._update();
         }

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -7,7 +7,7 @@ const byteArray = imports.byteArray;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Gio = imports.gi.Gio;
 
-const KubePopupMenuItem = GObject.registerClass({ GTypeName: 'KubePopupMenuItem' },
+var KubePopupMenuItem = GObject.registerClass({ GTypeName: 'KubePopupMenuItem' },
     class extends PopupMenu.PopupBaseMenuItem {
         _init(text, selected, params) {
             super._init(params);
@@ -25,7 +25,7 @@ const KubePopupMenuItem = GObject.registerClass({ GTypeName: 'KubePopupMenuItem'
             this.label = new St.Label({ text: this.text });
             this.box.add(this.label);
 
-            this.actor.add_child(this.box);
+            this.add_child(this.box);
 
             this.connect("activate", () => {
                 const path = GLib.build_filenamev([GLib.get_home_dir(), "/.kube/config"]);


### PR DESCRIPTION
Changed exported class declarations from `const` to `var`.

```
May 18 14:59:47 navi gnome-shell[108657]: Some code accessed the property 'KubeIndicator' on the module 'kubeIndicator'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
May 18 14:59:47 navi gnome-shell[108657]: JS ERROR: Extension kube_config@vvbogdanov87.gmail.com: TypeError: KubeIndicator.KubeIndicator is not a constructor
```

Removed direct access to object.actor (deprecated).

```
May 18 15:01:01 navi gnome-shell[109329]: Usage of object.actor is deprecated for KubeIndicator
                                          get@resource:///org/gnome/shell/ui/environment.js:411:29
                                          _init@/home/dylan/.local/share/gnome-shell/extensions/kube_config@vvbogdanov87.gmail.com/kubeIndicator.js:24:13
                                          ButtonBox@resource:///org/gnome/shell/ui/panelMenu.js:11:1
                                          PanelMenuButton@resource:///org/gnome/shell/ui/panelMenu.js:97:4
                                          KubeIndicator@/home/dylan/.local/share/gnome-shell/extensions/kube_config@vvbogdanov87.gmail.com/kubeIndicator.js:18:5
                                          enable@/home/dylan/.local/share/gnome-shell/extensions/kube_config@vvbogdanov87.gmail.com/extension.js:9:12
                                          _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:181:32
                                          _onEnabledExtensionsChanged/<@resource:///org/gnome/shell/ui/extensionSystem.js:525:35
                                          _onEnabledExtensionsChanged@resource:///org/gnome/shell/ui/extensionSystem.js:525:14
                                          createCheckedMethod/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:533:46
                                          enableExtension@resource:///org/gnome/shell/ui/extensionSystem.js:208:29
                                          EnableExtension@resource:///org/gnome/shell/ui/shellDBus.js:447:38
                                          _handleMethodCall@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:310:38
                                          _wrapJSObject/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:387:34
``` 

In addition to these changes, I needed to make the same `const` -> `var` change inside the bundled yaml library, the latest version of that library already uses `var`, so you might just need to update the version you're using in #26.

It might be best to make these changes in your yaml branch and close this PR, up to you.

I'm running gnome-shell 42.1 on arch.