### PR TITLE
Send only uuid

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ import { KubectlConfig } from './kubectl.js';
 
 export default class KubeConfigExtension extends Extension {
     enable() {
-        KubectlConfig.init(this);
+        KubectlConfig.init(this.metadata.uuid);
         this.kube = new KubeIndicator(this);
         Main.panel.addToStatusArea("Kube", this.kube);
     }

--- a/kubectl.js
+++ b/kubectl.js
@@ -12,8 +12,8 @@ class BaseKubectl {
      *
      * @param {Extension} extension
      */
-    static init(extension) {
-        this._extensionUUID = extension.metadata.uuid;
+    static init(uuid) {
+        this._extensionUUID = uuid;
 
         // ensure one executable is installed
         for (const exe of this._kubectlExes) {


### PR DESCRIPTION
@c84c  I got the message from the Gnome extensions review team when I published the new version:
```
You can send `this.uuid` instead of `this` for `KubectlConfig.init(this)` if that's all what you need.
```
The PR addresses the comments.