### PR TITLE
UI refactor and context cluster reachability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INSTALLNAME = kube_config@vvbogdanov87.gmail.com
 NAME = kube_config
 
 BASE_MODULES = extension.js metadata.json LICENSE README.md
-EXTRA_MODULES = kubeIndicator.js kubePopupMenuItem.js prefs.js kubectl.js commandLineUtil.js
+EXTRA_MODULES = kubeIndicator.js kubePopupMenuItem.js prefs.js kubectl.js commandLineUtil.js utils.js
 
 clean:
 	rm -rf _build

--- a/extension.js
+++ b/extension.js
@@ -2,12 +2,12 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { KubeIndicator } from './kubeIndicator.js';
-import { KubectlConfig } from './kubectl.js';
+import { Kubectl } from './kubectl.js';
 
 
 export default class KubeConfigExtension extends Extension {
     enable() {
-        KubectlConfig.init(this.metadata.uuid);
+        Kubectl.init(this);
         this.kube = new KubeIndicator(this);
         Main.panel.addToStatusArea("Kube", this.kube);
     }

--- a/kubeIndicator.js
+++ b/kubeIndicator.js
@@ -8,7 +8,7 @@ import GObject from 'gi://GObject';
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { KubePopupMenuItem } from './kubePopupMenuItem.js';
-import { KubectlConfig } from './kubectl.js';
+import { Kubectl } from './kubectl.js';
 import { throttle } from './utils.js';
 
 
@@ -90,13 +90,13 @@ export const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' 
         async _update() {
             this.contextsMenuSection.removeAll();
             try {
-                let currentContext = await KubectlConfig.getCurrentContext();
+                const currentContext = await Kubectl.getCurrentContext();
 
                 if (this._settings.get_boolean('show-current-context') === true) {
                     this.label.text = currentContext;
                 }
 
-                const contexts = await KubectlConfig.getContexts();
+                const contexts = await Kubectl.getContexts();
 
                 for (const context of contexts) {
                     const item = new KubePopupMenuItem(this._extensionObject, context, context === currentContext);

--- a/kubeIndicator.js
+++ b/kubeIndicator.js
@@ -67,11 +67,11 @@ export const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' 
             // add actions section menu
             const actionsSection = new PopupMenu.PopupMenuSection();
             const actionsBox = new St.BoxLayout({ vertical: false, style_class: 'popup-menu-ornament' });
-            actionsSection.actor.add(actionsBox);
+            actionsSection.actor.add_child(actionsBox);
             this.menu.addMenuItem(actionsSection);
 
             // a space
-            actionsBox.add(new St.BoxLayout({ x_expand: true }));
+            actionsBox.add_child(new St.BoxLayout({ x_expand: true }));
 
             // actions: add link to settings dialog
             const settingsMenuItem = new PopupMenu.PopupMenuItem('');
@@ -84,7 +84,7 @@ export const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' 
             settingsMenuItem.connect("activate", (_item, _event) =>
                 this._extensionObject.openPreferences()
             );
-            actionsBox.add(settingsMenuItem);
+            actionsBox.add_child(settingsMenuItem);
         }
 
         async _update() {

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -3,7 +3,7 @@ import Gio from 'gi://Gio';
 import St from 'gi://St';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-import { KubectlConfig } from './kubectl.js';
+import { Kubectl } from './kubectl.js';
 
 
 export const KubePopupMenuItem = GObject.registerClass(
@@ -23,7 +23,7 @@ export const KubePopupMenuItem = GObject.registerClass(
             }
             // connect signal
             this.connect("activate", (_item, _event) => {
-                KubectlConfig.useContext(this.label.get_text());
+                Kubectl.useContext(this.label.get_text());
             });
         }
     });

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -10,28 +10,20 @@ export const KubePopupMenuItem = GObject.registerClass(
     {
         GTypeName: 'KubePopupMenuItem'
     },
-    class extends PopupMenu.PopupBaseMenuItem {
+    class extends PopupMenu.PopupMenuItem {
         constructor(extensionObject, text, selected, params) {
-            super(params);
+            super(text.trim(), params);
             this._extensionObject = extensionObject;
-            this.text = text;
-            this.selected = selected;
-            this.box = new St.BoxLayout({ style_class: 'popup-combobox-item' });
-
-            if (this.selected === true) {
-                let gicon = Gio.icon_new_for_string(this._extensionObject.path + '/icons/ball.svg');
-                this.icon = new St.Icon({ gicon: gicon, style_class: 'system-status-icon', icon_size: 16 });
-                this.box.add_child(this.icon);
-                this.text = " " + this.text;
+            // current context ornament
+            if (selected === true) {
+                this.setOrnament(PopupMenu.Ornament.DOT);
+                //this.setOrnament(PopupMenu.Ornament.CHECK);
+            } else {
+                this.setOrnament(PopupMenu.Ornament.NONE);
             }
-
-            this.label = new St.Label({ text: this.text });
-            this.box.add_child(this.label);
-
-            this.add_child(this.box);
-
-            this.connect("activate", () => {
-                KubectlConfig.useContext(this.text.trim());
+            // connect signal
+            this.connect("activate", (_item, _event) => {
+                Kubectl.useContext(this.label.get_text());
             });
         }
     });

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -82,6 +82,9 @@ export const KubePopupMenuItem = GObject.registerClass(
         }
 
         async _updateClusterStatus() {
+            if (this._destroyed) {
+                return;
+            }
             const status = await Kubectl.clusterIsReachable(this.label.get_text());
             if (this._destroyed) {
                 return;
@@ -99,6 +102,9 @@ export const KubePopupMenuItem = GObject.registerClass(
          * @param {String} iconName
          */
         _setClusterStatusIcon(iconName) {
+            if (this._destroyed) {
+                return;
+            }
             if (this._clusterStatusIcon === null) {
                 this._clusterStatusIcon = new St.Icon({
                     icon_name: iconName,

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -23,7 +23,7 @@ export const KubePopupMenuItem = GObject.registerClass(
             }
             // connect signal
             this.connect("activate", (_item, _event) => {
-                Kubectl.useContext(this.label.get_text());
+                KubectlConfig.useContext(this.label.get_text());
             });
         }
     });

--- a/kubePopupMenuItem.js
+++ b/kubePopupMenuItem.js
@@ -1,5 +1,6 @@
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
-import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import St from 'gi://St';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
@@ -11,9 +12,19 @@ export const KubePopupMenuItem = GObject.registerClass(
         GTypeName: 'KubePopupMenuItem'
     },
     class extends PopupMenu.PopupMenuItem {
+        /**
+         * @param {Extension} extensionObject
+         * @param {String} text
+         * @param {boolean} selected
+         * @param {Object} params : PopupBaseMenuItem additional item properties (https://gjs.guide/extensions/topics/popup-menu.html#popupbasemenuitem)
+         */
         constructor(extensionObject, text, selected, params) {
             super(text.trim(), params);
             this._extensionObject = extensionObject;
+
+            // FIXME: How to know if item is already disposed?
+            this._destroyed = false;
+
             // current context ornament
             if (selected === true) {
                 this.setOrnament(PopupMenu.Ornament.DOT);
@@ -21,9 +32,64 @@ export const KubePopupMenuItem = GObject.registerClass(
             } else {
                 this.setOrnament(PopupMenu.Ornament.NONE);
             }
+            this.connect('destroy', this._onDestroy.bind(this));
+
+            // initialize cluster status icon
+            this._clusterStatusIcon = null;
+            this._setClusterStatusIcon('network-error-symbolic');
+
             // connect signal
             this.connect("activate", (_item, _event) => {
                 Kubectl.useContext(this.label.get_text());
             });
+
+            // update cluster status, i.e. cluster status icon
+            this._updateClusterStatus().catch(e => console.error(e));
+
+            // ... and schedule status update each 5 seconds
+            // TODO: make timer configurable in extension settings and/or
+            //       based on device power settings.
+            this._timerid = GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT,
+                5000,
+                () => this._updateClusterStatus().catch(e => console.error(e))
+            );
+        }
+
+        async _updateClusterStatus() {
+            const status = await Kubectl.clusterIsReachable(this.label.get_text());
+            if (this._destroyed) {
+                return;
+            }
+            if (status) {
+                this._setClusterStatusIcon('network-transmit-receive-symbolic');
+            } else {
+                this._setClusterStatusIcon('network-error-symbolic');
+            }
+        }
+
+        /**
+         * Set cluster status icon.
+         *
+         * @param {String} iconName
+         */
+        _setClusterStatusIcon(iconName) {
+            if (this._clusterStatusIcon === null) {
+                this._clusterStatusIcon = new St.Icon({
+                    icon_name: iconName,
+                    style_class: 'popup-menu-icon',
+                    x_align: Clutter.ActorAlign.END,
+                    x_expand: true,
+                    y_expand: true,
+                });
+                this.add_child(this._clusterStatusIcon);
+            } else {
+                this._clusterStatusIcon.set_icon_name(iconName);
+            }
+        }
+
+        _onDestroy() {
+            this._destroyed = true;
+            this._stopClusterPoll();
         }
     });

--- a/kubectl.js
+++ b/kubectl.js
@@ -31,6 +31,48 @@ class BaseKubectl {
 export class Kubectl extends BaseKubectl {
 
     /**
+     * Get kubectl version.
+     *
+     * @param {String|undefined} context
+     * @returns {Promise<String>}
+     */
+    static async version(context) {
+        if (this._kubectlExe === null) {
+            return "";
+        }
+
+        let argv = [this._kubectlExe, `--request-timeout=3`];
+        if (!(context === null || context === undefined)) {
+            argv.push(`--context=${context}`);
+        }
+        argv.push(`version`);
+
+        try {
+            const output = await execCommunicateAsync(argv);
+            return output;
+        } catch (_e) {
+            //console.error(`${Kubectl._extensionUUID} cannot retrieve kubeconfig contexts: ${_e}`);
+            return "";
+        }
+    }
+
+    /**
+     * Check if `context` is reachable.
+     * If `context` not specified, check for current context.
+     * The kubectl version is the lightweight method to check reachability.
+     *
+     * @param {String|undefined} context
+     * @returns {Promise<String>}
+     */
+    static async clusterIsReachable(context) {
+        if (this._kubectlExe === null) {
+            return false;
+        }
+        const v = await Kubectl.version(context);
+        return v !== "";
+    }
+
+    /**
      * Get kubeconfg contexts
      *
      * @returns {Promise<String[]>}

--- a/kubectl.js
+++ b/kubectl.js
@@ -28,7 +28,7 @@ class BaseKubectl {
     }
 }
 
-export class KubectlConfig extends BaseKubectl {
+export class Kubectl extends BaseKubectl {
 
     /**
      * Get kubeconfg contexts
@@ -40,7 +40,7 @@ export class KubectlConfig extends BaseKubectl {
             return [];
         }
 
-        const argv = [KubectlConfig._kubectlExe, 'config', 'get-contexts', '-oname'];
+        const argv = [this._kubectlExe, 'config', 'get-contexts', '-oname'];
         try {
             const output = await execCommunicateAsync(argv);
             const lines = output.split('\n');
@@ -61,7 +61,7 @@ export class KubectlConfig extends BaseKubectl {
             return "";
         }
 
-        const argv = [KubectlConfig._kubectlExe, 'config', 'current-context'];
+        const argv = [this._kubectlExe, 'config', 'current-context'];
         try {
             return await execCommunicateAsync(argv);
         } catch (e) {
@@ -80,7 +80,7 @@ export class KubectlConfig extends BaseKubectl {
             return false;
         }
 
-        const argv = [KubectlConfig._kubectlExe, 'config', 'use-context', `${context}`];
+        const argv = [this._kubectlExe, 'config', 'use-context', `${context}`];
         try {
             await execCommunicateAsync(argv);
             return true;

--- a/prefs.js
+++ b/prefs.js
@@ -1,10 +1,14 @@
 import Gio from 'gi://Gio';
 import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
 
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class KubeConfigExtensionPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
+        // Create a settings object
+        window._settings = this.getSettings();
+
         // Create a preferences page, with a single group
         const page = new Adw.PreferencesPage({
             title: _('General'),
@@ -25,10 +29,34 @@ export default class KubeConfigExtensionPreferences extends ExtensionPreferences
         });
         group.add(row);
 
-        // Create a settings object and bind the row to the `show-current-context` key
-        window._settings = this.getSettings();
+        // Bind the row to the `show-current-context` key
         window._settings.bind('show-current-context', row, 'active',
             Gio.SettingsBindFlags.DEFAULT);
+
+        const groupInstrumentation = new Adw.PreferencesGroup({
+            title: _('Instrumentation'),
+            description: _('Configure extension tools'),
+        });
+        page.add(groupInstrumentation);
+
+        // Create a new preferences row
+        const clusterReachability = new Adw.SpinRow({
+            title: _('Poll context cluster every (sec)'),
+            subtitle: _('Cluster context reachability poll interval'),
+            adjustment: new Gtk.Adjustment({
+                lower: 5,
+                upper: 60,
+                step_increment: 1
+            })
+        });
+
+        groupInstrumentation.add(clusterReachability);
+
+        // Bind the row to the `cluster-poll-interval-seconds` key
+        window._settings.bind('cluster-poll-interval-seconds', clusterReachability,
+            'value', Gio.SettingsBindFlags.DEFAULT);
+
+
     }
 }
 

--- a/schemas/org.gnome.shell.extensions.kube_config.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kube_config.gschema.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <schemalist gettext-domain="gnome-shell-extensions">
-	<schema path="/org/gnome/shell/extensions/kube-config/" id="org.gnome.shell.extensions.kube-config">
-		<key type="b" name="show-current-context">
+    <schema path="/org/gnome/shell/extensions/kube-config/" id="org.gnome.shell.extensions.kube-config">
+        <key type="b" name="show-current-context">
             <default>false</default>
             <summary>Show current context</summary>
             <description></description>
         </key>
-	</schema>
+        <key type="i" name="cluster-poll-interval-seconds">
+            <default>5</default>
+            <summary>Seconds before next update</summary>
+            <description>This is the seconds after extension updates the cluster reachability for the context</description>
+        </key>
+    </schema>
 </schemalist>

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,24 @@
+
+/**
+ *
+ * @param {Function} mainFunction
+ * @param {int} delayMs throttle delay in milliseconds
+ * @returns
+ */
+export function throttle(mainFunction, delayMs) {
+    let timerFlag = null; // Variable to keep track of the timer
+
+    // Returning a throttled version
+    return (...args) => {
+        if (timerFlag === null) { // If there is no timer currently running
+            // Execute the main function
+            mainFunction(...args);
+            // Set a timer to clear the timerFlag after the specified delay
+            timerFlag = setTimeout(() => {
+                // Clear the timerFlag to allow the main function to be executed again
+                timerFlag = null;
+            }, delayMs);
+        }
+    };
+}
+


### PR DESCRIPTION
## Description

This PR refactor UI layout to align style to GNOME Style and a context cluster reachability polling `kubectl --context=<context-name> version` with a configurable interval.

## Changes preview

Extension Menu            |  Extension Preferences
:-------------------------:|:-------------------------:
![KubeConfig_UI_refactor_and_cluster_reach](https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig/assets/616846/9607da79-9e0b-4c08-ad32-2c2ebaaa7085) |  ![image](https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig/assets/616846/b1d0b2b2-1af8-4d97-a71f-9700e8b848fd)
