### PR TITLE
Fix "Don't modify an object's reference count in JS"

### DIFF
--- a/kubeIndicator.js
+++ b/kubeIndicator.js
@@ -133,7 +133,6 @@ export const KubeIndicator = GObject.registerClass({ GTypeName: 'KubeIndicator' 
             super.destroy();
             for (const monitor of this._monitors) {
                 monitor.cancel();
-                monitor.unref();
             }
             this._monitors = [];
         }

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,6 @@
     "url": "https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig",
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [
-        "46"
+        "47"
     ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [
         "47",
-        "48"
+        "48",
+        "49"
     ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "Kube Config",
     "description": "Switches kube config context",
-    "uuid": "kube_config@maxime-genet54@hotmail.fr",
+    "uuid": "kube_config@mochacaffe.github.com",
     "url": "https://github.com/MochaCaffe/gnome-shell-extension-kubeconfig.git",
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,13 @@
 {
     "name": "Kube Config",
     "description": "Switches kube config context",
-    "uuid": "kube_config@vvbogdanov87.gmail.com",
-    "url": "https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig",
+    "uuid": "kube_config@maxime-genet54@hotmail.fr",
+    "url": "https://github.com/MochaCaffe/gnome-shell-extension-kubeconfig.git",
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [
         "47",
         "48",
-        "49"
+        "49",
+        "50"
     ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     "url": "https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig",
     "settings-schema": "org.gnome.shell.extensions.kube-config",
     "shell-version": [
-        "47"
+        "47",
+        "48"
     ]
 }


### PR DESCRIPTION
This issue is occurring in Gnome 47.
It looks like the unref() method called on a monitor Object is not supported anymore: [https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig/blob/85e71bdd2b878a30b8e12030d8fced4dccd55ada/kubeIndicator.js#L136](https://github.com/vvbogdanov87/gnome-shell-extension-kubeconfig/blob/85e71bdd2b878a30b8e12030d8fced4dccd55ada/kubeIndicator.js#L136)

Consequence: the extension disappears randomly

Stack trace:
```
Extension kube_config@vvbogdanov87.gmail.com: Error: Don't modify an object's reference count in JS.
                                            
                                            Stack trace:
                                              unsupportedRefcountingMethod@resource:///org/gnome/gjs/modules/core/overrides/GObject.js:898:15
                                              destroy@file:///home/maxime/.local/share/gnome-shell/extensions/kube_config@vvbogdanov87.gmail.com/kubeIndicator.js:136:25
                                              disable@file:///home/maxime/.local/share/gnome-shell/extensions/kube_config@vvbogdanov87.gmail.com/extension.js:16:19
                                              _callExtensionDisable@resource:///org/gnome/shell/ui/extensionSystem.js:215:32
                                              _onEnabledExtensionsChanged@resource:///org/gnome/shell/ui/extensionSystem.js:637:24
                                              async*_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:824:20
                                              ExtensionManager/<@resource:///org/gnome/shell/ui/extensionSystem.js:46:18
                                              _callHandlers@resource:///org/gnome/gjs/modules/core/_signals.js:130:42
                                              _emit@resource:///org/gnome/gjs/modules/core/_signals.js:119:10
                                              _sync@resource:///org/gnome/shell/ui/sessionMode.js:205:14
                                              pushMode@resource:///org/gnome/shell/ui/sessionMode.js:167:14
                                              activate@resource:///org/gnome/shell/ui/screenShield.js:614:34
                                              lock@resource:///org/gnome/shell/ui/screenShield.js:681:14
                                              LockAsync@resource:///org/gnome/shell/ui/shellDBus.js:523:28
                                              _handleMethodCall@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:373:35
                                              _wrapJSObject/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:408:34
                                              @resource:///org/gnome/shell/ui/init.js:21:20

```

My current solution is to remove this call, as the method cancel() is already called on the object, and the JS array containing all monitors references is cleaned after.